### PR TITLE
improvements and PC speaker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,9 +32,12 @@ keyboard.o: src/drivers/keyboard.c
 	$(CC) $(CFLAGS) -c $< -o $@
 
 serial.o: src/drivers/serial.c
+	$(CC) $(CFLAGS) -c $< -o $@\
+
+pc_speaker.o: src/drivers/pc_speaker.c
 	$(CC) $(CFLAGS) -c $< -o $@
 
-$(KERNEL): boot.o kernel.o desktop.o string.o io.o font.o keyboard.o serial.o
+$(KERNEL): boot.o kernel.o desktop.o string.o io.o font.o keyboard.o serial.o pc_speaker.o
 	$(CC) $(LDFLAGS) -o $@ $^
 
 iso: $(KERNEL)
@@ -48,6 +51,9 @@ run: iso
 
 run-serial: iso
 	qemu-system-i386 -cdrom $(ISO_NAME) -serial stdio
+
+run-sound: iso
+	qemu-system-i386 -cdrom $(ISO_NAME) -audiodev alsa,id=snd0 -machine pcspk-audiodev=snd0
 
 clean:
 	rm -rf *.o $(KERNEL) $(ISO_NAME) isodir

--- a/src/drivers/pc_speaker.c
+++ b/src/drivers/pc_speaker.c
@@ -1,0 +1,52 @@
+#include "pc_speaker.h"
+#include "../io.h"
+
+//delay function (busy wait)
+static void delay_ms(uint32_t ms) {
+    //rough approximation timing
+    for (uint32_t i = 0; i < ms * 1000; i++) {
+        __asm__ volatile("nop");
+    }
+}
+
+void speaker_init(void) {
+    //initialize speaker ensure it off initially
+    speaker_stop();
+}
+
+void speaker_play_freq(uint32_t frequency) {
+    if (frequency == 0) {
+        speaker_stop();
+        return;
+    }
+    
+    //calculate divisor for PIT
+    uint32_t divisor = 1193180 / frequency;
+    
+    //configure PIT channel 2 for square wave
+    outb(PIT_COMMAND, PIT_SPEAKER_CMD);
+    
+    //send divisor (low byte first then high byte)
+    outb(PIT_CHANNEL_2, (uint8_t)(divisor & 0xFF));
+    outb(PIT_CHANNEL_2, (uint8_t)((divisor >> 8) & 0xFF));
+    
+    //enable speaker
+    uint8_t speaker_reg = inb(SPEAKER_PORT);
+    outb(SPEAKER_PORT, speaker_reg | 0x03);
+}
+
+void speaker_stop(void) {
+    //disable speaker
+    uint8_t speaker_reg = inb(SPEAKER_PORT);
+    outb(SPEAKER_PORT, speaker_reg & 0xFC);
+}
+
+void speaker_beep(uint32_t frequency, uint32_t duration_ms) {
+    speaker_play_freq(frequency);
+    delay_ms(duration_ms);
+    speaker_stop();
+}
+
+void speaker_play_note(uint32_t note, uint32_t duration_ms) {
+    speaker_beep(note, duration_ms);
+}

--- a/src/drivers/pc_speaker.h
+++ b/src/drivers/pc_speaker.h
@@ -1,0 +1,56 @@
+#ifndef SPEAKER_H
+#define SPEAKER_H
+
+#include <stdint.h>
+
+//PC Speaker ports
+#define SPEAKER_PORT        0x61
+#define PIT_CHANNEL_2       0x42
+#define PIT_COMMAND         0x43
+
+//PIT command for channel 2
+#define PIT_SPEAKER_CMD     0xB6
+
+//musical note frequencies 
+#define NOTE_C4     262
+#define NOTE_CS4    277
+#define NOTE_D4     294
+#define NOTE_DS4    311
+#define NOTE_E4     330
+#define NOTE_F4     349
+#define NOTE_FS4    370
+#define NOTE_G4     392
+#define NOTE_GS4    415
+#define NOTE_A4     440
+#define NOTE_AS4    466
+#define NOTE_B4     494
+#define NOTE_C5     523
+#define NOTE_CS5    554
+#define NOTE_D5     587
+#define NOTE_DS5    622
+#define NOTE_E5     659
+#define NOTE_F5     698
+#define NOTE_FS5    740
+#define NOTE_G5     784
+#define NOTE_GS5    831
+#define NOTE_A5     880
+#define NOTE_AS5    932
+#define NOTE_B5     988
+
+#define FREQ_BEEP   1000
+#define FREQ_ERROR  200
+#define FREQ_SUCCESS 800
+
+//function declarations
+void speaker_init(void);
+void speaker_play_freq(uint32_t frequency);
+void speaker_stop(void);
+void speaker_beep(uint32_t frequency, uint32_t duration_ms);
+void speaker_play_note(uint32_t note, uint32_t duration_ms);
+
+//macros
+#define BEEP() speaker_beep(FREQ_BEEP, 100)
+#define ERROR_SOUND() speaker_beep(FREQ_ERROR, 300)
+#define SUCCESS_SOUND() speaker_beep(FREQ_SUCCESS, 150)
+
+#endif


### PR DESCRIPTION
added a PC speaker driver (see: src/drivers/pc_speaker.c/h) Improved ice editor (you can move the cursor across rows and columns using arrow keys) fixed 'colour' command handling
removed scancode's from kernel.c 
as they already exist in src/drivers/keyboard.h
To use PC speaker first you have to init it with 
'speaker_init();'
and then you can e.x use it like this:
`speaker_beep(750, 200);        //750 Hz 200 ms`
and added a new target to makefile 'run-sound'