### PR TITLE
interrupts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,11 @@ font.o: src/font.c
 keyboard.o: src/drivers/keyboard.c
 	$(CC) $(CFLAGS) -c $< -o $@
 
+mouse.o: src/drivers/mouse.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
 serial.o: src/drivers/serial.c
-	$(CC) $(CFLAGS) -c $< -o $@\
+	$(CC) $(CFLAGS) -c $< -o $@
 
 pc_speaker.o: src/drivers/pc_speaker.c
 	$(CC) $(CFLAGS) -c $< -o $@
@@ -40,7 +43,22 @@ pc_speaker.o: src/drivers/pc_speaker.c
 vga.o: src/gui/vga.c
 	$(CC) $(CFLAGS) -c $< -o $@
 
-$(KERNEL): boot.o kernel.o desktop.o string.o io.o font.o keyboard.o serial.o pc_speaker.o vga.o
+idt.o: src/interrupts/idt.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
+irq.o: src/interrupts/irq.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
+pic.o: src/interrupts/pic.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
+isr.o: src/interrupts/isr.asm
+	$(ASM) $(ASMFLAGS) $< -o $@
+
+timer.o: src/drivers/timer.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
+$(KERNEL): boot.o kernel.o desktop.o string.o io.o font.o keyboard.o mouse.o serial.o pc_speaker.o vga.o idt.o irq.o pic.o isr.o timer.o
 	$(CC) $(LDFLAGS) -o $@ $^
 
 iso: $(KERNEL)

--- a/src/drivers/exFAT.h
+++ b/src/drivers/exFAT.h
@@ -1,10 +1,10 @@
-#define EXFAT_H
 #ifndef EXFAT_H
+#define EXFAT_H
 
 typedef struct fat_extBS_32{
     unsigned int table_size_32;
     
-}__attrubute__((packed)) fat_extBS_32_t;
+}__attribute__((packed)) fat_extBS_32_t;
 
 
 #endif

--- a/src/drivers/keyboard.c
+++ b/src/drivers/keyboard.c
@@ -1,8 +1,56 @@
 #include "keyboard.h"
 #include "../io.h"
+#include "../interrupts/irq.h"
+#include "../interrupts/pic.h"
+#include "timer.h"
 #include <stdint.h>
 
 int shift_pressed = 0;
+
+//ing buffer for ASCII character
+static volatile char keybuf[64];
+static volatile uint8_t key_head = 0, key_tail = 0;
+//ring buffer for key events (ASCII or special like arrows)
+static volatile unsigned short evbuf[64];
+static volatile uint8_t ev_head = 0, ev_tail = 0;
+
+static volatile uint8_t key_state[128];      //pressed state per scancode (0x00-0x7F)
+static volatile uint8_t ext_key_state[128];  //pressed state for extended scancodes (0xE0-prefixed)
+static volatile uint8_t e0_pending = 0;      //whether next scancode is extended
+
+//key repeat state
+#define KBD_REPEAT_DELAY_TICKS  20  //initial delay before repeating (~200ms if 100Hz)
+#define KBD_REPEAT_RATE_TICKS    3  //repeat rate (~33Hz if 100Hz)
+static volatile uint8_t  repeat_active = 0;
+static volatile uint8_t  repeat_is_ext = 0;
+static volatile uint8_t  repeat_scancode = 0; //base scancode (without 0xE0/0x80)
+static volatile uint32_t repeat_next_tick = 0;
+
+static inline int keybuf_empty(void) { return key_head == key_tail; }
+static inline void keybuf_push(char c) {
+    uint8_t next = (uint8_t)((key_head + 1) & 63);
+    if (next != key_tail) { keybuf[key_head] = c; key_head = next; }
+}
+
+static inline int evbuf_empty(void) { return ev_head == ev_tail; }
+static inline void evbuf_push(unsigned short e) {
+    uint8_t next = (uint8_t)((ev_head + 1) & 63);
+    if (next != ev_tail) { evbuf[ev_head] = e; ev_head = next; }
+}
+
+static inline char keybuf_pop(void) {
+    if (keybuf_empty()) return 0;
+    char c = keybuf[key_tail];
+    key_tail = (uint8_t)((key_tail + 1) & 63);
+    return c;
+}
+
+static inline unsigned short evbuf_pop(void) {
+    if (evbuf_empty()) return 0;
+    unsigned short e = evbuf[ev_tail];
+    ev_tail = (uint8_t)((ev_tail + 1) & 63);
+    return e;
+}
 
 static char sc_to_ascii(uint8_t sc){
     if(sc == 0x2A || sc == 0x36){ shift_pressed = 1; return 0; }
@@ -11,24 +59,169 @@ static char sc_to_ascii(uint8_t sc){
     return 0;
 }
 
-char kb_poll(void) {
-    if (inb(kbd_status_port) & 1) {
-        uint8_t scancode = inb(kbd_data_port);
-        return sc_to_ascii(scancode);
-    }
-    return 0; // no key pressed
-}
-
-
-char getkey(void){
-    while (inb(0x64) & 1) {
-        (void)inb(0x60);
-    }
-
-    for (;;) {
-        if (inb(kbd_status_port) & 1) {
-            uint8_t scancode = inb(kbd_data_port);
-            return sc_to_ascii(scancode);
+static void keyboard_irq_handler(void) {
+    uint8_t scancode = inb(kbd_data_port);
+    if (scancode == 0xE0) { e0_pending = 1; return; }
+    if (scancode & 0x80) {
+        //key release
+        uint8_t code = (uint8_t)(scancode & 0x7F);
+        if (e0_pending) {
+            ext_key_state[code] = 0;
+            e0_pending = 0;
+            //stop repeating if this was the repeating extended key
+            if (repeat_active && repeat_is_ext && repeat_scancode == code) {
+                repeat_active = 0;
+            }
+        } else {
+            key_state[code] = 0;
+            if (scancode == 0xAA || scancode == 0xB6) shift_pressed = 0; //shift up
+            //stop repeating if this was the repeating normal key
+            if (repeat_active && !repeat_is_ext && repeat_scancode == code) {
+                repeat_active = 0;
+            }
+        }
+        return;
+    } else {
+        //key press
+        if (e0_pending) {
+            e0_pending = 0;
+            //arrows we care about
+            if (scancode == 0x4B || scancode == 0x4D || scancode == 0x48 || scancode == 0x50) {
+                if (ext_key_state[scancode]) return; //ignore hardware auto-repeat we will do software repeat
+                ext_key_state[scancode] = 1;
+                unsigned short ev = (unsigned short)(0xE000u | scancode);
+                evbuf_push(ev);
+                //configure repeat for extended key
+                repeat_is_ext = 1;
+                repeat_scancode = scancode;
+                repeat_active = 1;
+                repeat_next_tick = timer_get_ticks() + KBD_REPEAT_DELAY_TICKS;
+                return;
+            }
+            //ignore other extended keys for now
+            return;
+        }
+        if (scancode == 0x2A || scancode == 0x36) { 
+            shift_pressed = 1; return;
+         } //shift down
+        if (key_state[scancode]) return; //ignore hardware auto-repeat while held software repeat will handle
+        key_state[scancode] = 1;
+        char ch = sc_to_ascii(scancode);
+        if (ch) {
+            keybuf_push(ch);
+            evbuf_push((unsigned short)(unsigned char)ch);
+            //set up repeat for this normal key
+            repeat_is_ext = 0;
+            repeat_scancode = scancode;
+            repeat_active = 1;
+            repeat_next_tick = timer_get_ticks() + KBD_REPEAT_DELAY_TICKS;
         }
     }
+}
+
+char kb_poll(void) {
+    //prefer IRQ-buffered input
+    char c = keybuf_pop();
+    if (c) return c;
+    //fallback to hardware poll (e.x if interrupts are disabled for some reaosn)
+    if (inb(kbd_status_port) & 1) {
+        uint8_t scancode = inb(kbd_data_port);
+        if (scancode == 0xE0) { e0_pending = 1; return 0; }
+        if (scancode & 0x80) {
+            uint8_t code = (uint8_t)(scancode & 0x7F);
+            if (e0_pending) { ext_key_state[code] = 0; e0_pending = 0; }
+            else { key_state[code] = 0; if (scancode == 0xAA || scancode == 0xB6) shift_pressed = 0; }
+            return 0;
+        } else {
+            if (e0_pending) {
+                e0_pending = 0;
+                if (scancode == 0x4B || scancode == 0x4D || scancode == 0x48 || scancode == 0x50) {
+                    if (ext_key_state[scancode]) return 0;
+                    ext_key_state[scancode] = 1;
+                    unsigned short ev = (unsigned short)(0xE000u | scancode);
+                    evbuf_push(ev);
+                    return 0;
+                }
+                return 0;
+            }
+            if (scancode == 0x2A || scancode == 0x36) { shift_pressed = 1; return 0; }
+            if (key_state[scancode]) return 0; //ignore auto-repeat
+            key_state[scancode] = 1;
+            char ch = sc_to_ascii(scancode);
+            if (ch) { keybuf_push(ch); evbuf_push((unsigned short)(unsigned char)ch); }
+            return ch;
+        }
+    }
+    return 0; //no key pressed
+}
+
+char getkey(void){
+    for (;;) {
+        //first consume buffered input
+        char c = kb_poll();
+        if (c) return c;
+
+        //software key repeat for ASCII keys only
+        if (repeat_active && !repeat_is_ext) {
+            uint32_t now = timer_get_ticks();
+            if ((int32_t)(now - repeat_next_tick) >= 0) {
+                char rc = sc_to_ascii(repeat_scancode);
+                if (rc) {
+                    //schedule next repeat and return
+                    repeat_next_tick = now + KBD_REPEAT_RATE_TICKS;
+                    return rc;
+                } else {
+                    //no valid ascii from scancode stop repeating
+                    repeat_active = 0;
+                }
+            }
+        }
+        __asm__ volatile ("hlt"); //wait for next IRQ to save CPU
+    }
+}
+
+unsigned short kbd_getevent(void){
+    for(;;){
+        //buffered events first
+        unsigned short e = evbuf_pop();
+        if (e) return e;
+
+        //also poll to convert pending scan codes into events in fallback
+        (void)kb_poll();
+
+        //software repeat for both ascii and extended keys
+        if (repeat_active) {
+            uint32_t now = timer_get_ticks();
+            if ((int32_t)(now - repeat_next_tick) >= 0) {
+                repeat_next_tick = now + KBD_REPEAT_RATE_TICKS;
+                if (repeat_is_ext) {
+                    return (unsigned short)(0xE000u | repeat_scancode);
+                } else {
+                    char rc = sc_to_ascii(repeat_scancode);
+                    if (rc) return (unsigned short)(unsigned char)rc;
+                    //invalid ascii -> stop repeating
+                    repeat_active = 0;
+                }
+            }
+        }
+        __asm__ volatile ("hlt");
+    }
+}
+
+void keyboard_init(void) {
+    irq_install_handler(1, keyboard_irq_handler);
+    pic_clear_mask(1); //unmask IRQ1
+}
+
+void kbd_flush(void) {
+    __asm__ volatile ("cli");
+    key_head = key_tail = 0;
+    ev_head = ev_tail = 0;
+    e0_pending = 0;
+    for (int i = 0; i < 128; ++i) { key_state[i] = 0; ext_key_state[i] = 0; }
+    repeat_active = 0;
+    repeat_is_ext = 0;
+    repeat_scancode = 0;
+    repeat_next_tick = 0;
+    __asm__ volatile ("sti");
 }

--- a/src/drivers/keyboard.h
+++ b/src/drivers/keyboard.h
@@ -6,6 +6,11 @@
 
 extern int shift_pressed;
 
+#define K_ARROW_LEFT  0xE04B
+#define K_ARROW_RIGHT 0xE04D
+#define K_ARROW_UP    0xE048
+#define K_ARROW_DOWN  0xE050
+
 static const char scancode_map[128] = {
  0,27,'1','2','3','4','5','6','7','8','9','0','-','=', '\b',
  '\t','q','w','e','r','t','y','u','i','o','p','[',']','\n',0,
@@ -20,7 +25,15 @@ static const char scancode_map_shift[128] = {
  'C','V','B','N','M','<','>','?',0,'*',0,' '
 };
 
+//read next ASCII character ignores special keys
 char getkey();
+//non-blocking ASCII poll returns 0 if none
 char kb_poll();
+//read next key event  returns ASCII in low byte for printable keys
+//or one of the K_* special codes for extended keys
+unsigned short kbd_getevent(void);
+void keyboard_init(void);
+//clear any pending keyboard events and reset repeat state
+void kbd_flush(void);
 
 #endif

--- a/src/drivers/mouse.c
+++ b/src/drivers/mouse.c
@@ -1,0 +1,83 @@
+#include "mouse.h"
+#include "../io.h"
+#include "../interrupts/irq.h"
+#include "../interrupts/pic.h"
+
+//IRQ12-driven PS/2 mouse handler with packet ring buffer
+typedef struct { 
+    int8_t b[3]; 
+} mouse_pkt_t;
+static volatile mouse_pkt_t pktbuf[16];
+static volatile uint8_t pkt_head = 0, pkt_tail = 0;
+
+static inline int pkt_empty(void) { 
+    return pkt_head == pkt_tail; 
+}
+static inline void pkt_push(int8_t b0, int8_t b1, int8_t b2) {
+    uint8_t next = (uint8_t)((pkt_head + 1) & 15);
+    if (next != pkt_tail) {
+        pktbuf[pkt_head].b[0] = b0;
+        pktbuf[pkt_head].b[1] = b1;
+        pktbuf[pkt_head].b[2] = b2;
+        pkt_head = next;
+    }
+}
+
+static int8_t ib0, ib1, ib2; //in progress bytes
+static uint8_t mcycle = 0;
+
+static void mouse_wait(uint8_t type) {
+    uint32_t timeout = 100000;
+    if (type == 0) {
+        while (timeout--) { if (inb(0x64) & 1) return; }
+    } else {
+        while (timeout--) { if ((inb(0x64) & 2) == 0) return; }
+    }
+}
+
+static void mouse_write(uint8_t val) {
+    mouse_wait(1); outb(0x64, 0xD4);
+    mouse_wait(1); outb(0x60, val);
+}
+
+static uint8_t mouse_read(void) {
+    mouse_wait(0);
+    return inb(0x60);
+}
+
+static void mouse_irq_handler(void) {
+    uint8_t data = inb(0x60); //IRQ12 guarantees this is mouse data
+    if (mcycle == 0) {
+        if (!(data & 0x08)) return; //resync first byte must have bit3 set
+        ib0 = (int8_t)data; mcycle = 1; return;
+    }
+    if (mcycle == 1) { ib1 = (int8_t)data; mcycle = 2; return; }
+    ib2 = (int8_t)data; mcycle = 0; pkt_push(ib0, ib1, ib2);
+}
+
+void mouse_init(void) {
+    //enable auoxiliary device and its IRQ in controller command byte
+    mouse_wait(1); outb(0x64, 0xA8);      //enable auxiliary device
+    mouse_wait(1); outb(0x64, 0x20);      //get command byte
+    mouse_wait(0); uint8_t status = inb(0x60) | 2; //enable IRQ12 in controller
+    mouse_wait(1); outb(0x64, 0x60);      //set command byte
+    mouse_wait(1); outb(0x60, status);
+
+    //configure mouse
+    mouse_write(0xF6); (void)mouse_read(); //set defaults
+    mouse_write(0xF4); (void)mouse_read(); //enable data reporting (streaming)
+
+    //install IRQ12handler unmask IRQ2 and IRQ12
+    irq_install_handler(12, mouse_irq_handler);
+    pic_clear_mask(2);   //cascade for slave PIC
+    pic_clear_mask(12);  //mouse IRQ
+}
+
+int mouse_poll_packet(int8_t out_bytes[3]) {
+    if (pkt_empty()) return 0;
+    out_bytes[0] = pktbuf[pkt_tail].b[0];
+    out_bytes[1] = pktbuf[pkt_tail].b[1];
+    out_bytes[2] = pktbuf[pkt_tail].b[2];
+    pkt_tail = (uint8_t)((pkt_tail + 1) & 15);
+    return 1;
+}

--- a/src/drivers/mouse.h
+++ b/src/drivers/mouse.h
@@ -1,0 +1,12 @@
+#ifndef MOUSE_H
+#define MOUSE_H
+
+#include <stdint.h>
+
+//initialize PS/2 mouse in streaming mode (poll-based)
+void mouse_init(void);
+
+//poll for a full 3-byte PS/2 packet returns 1 if packet ready and copies into out_bytes[3]
+int mouse_poll_packet(int8_t out_bytes[3]);
+
+#endif

--- a/src/drivers/timer.c
+++ b/src/drivers/timer.c
@@ -1,0 +1,36 @@
+#include "timer.h"
+#include "../interrupts/irq.h"
+#include "../interrupts/pic.h"
+#include "../io.h"
+
+#define PIT_FREQUENCY 1193180u
+
+static volatile uint64_t g_ticks = 0;
+static uint32_t g_hz = 0;
+
+static void timer_irq_handler(void) {
+    g_ticks++;
+}
+
+void timer_init(uint32_t frequency) {
+    if (frequency == 0) frequency = 100; //default
+    g_hz = frequency;
+    uint32_t divisor = PIT_FREQUENCY / frequency;
+
+    //register IRQ0 handler and unmask IRQ0
+    irq_install_handler(0, timer_irq_handler);
+    pic_clear_mask(0);
+
+    //command: channel 0 access lobyte/hibyte mode 3 (square wave) binary
+    outb(0x43, 0x36);
+    outb(0x40, (uint8_t)(divisor & 0xFF));
+    outb(0x40, (uint8_t)((divisor >> 8) & 0xFF));
+}
+
+uint64_t timer_get_ticks(void) {
+    return g_ticks;
+}
+
+uint32_t timer_get_frequency(void) {
+    return g_hz;
+}

--- a/src/drivers/timer.h
+++ b/src/drivers/timer.h
@@ -1,0 +1,10 @@
+#ifndef TIMER_H
+#define TIMER_H
+
+#include <stdint.h>
+
+void timer_init(uint32_t frequency);
+uint64_t timer_get_ticks(void);
+uint32_t timer_get_frequency(void);
+
+#endif

--- a/src/interrupts/idt.c
+++ b/src/interrupts/idt.c
@@ -1,0 +1,75 @@
+#include "idt.h"
+#include <stdint.h>
+
+extern void irq0();
+extern void irq1();
+extern void irq2();
+extern void irq3();
+extern void irq4();
+extern void irq5();
+extern void irq6();
+extern void irq7();
+extern void irq8();
+extern void irq9();
+extern void irq10();
+extern void irq11();
+extern void irq12();
+extern void irq13();
+extern void irq14();
+extern void irq15();
+
+static idt_entry_t idt[256];
+static idt_ptr_t   idtp;
+
+static inline void lidt(const idt_ptr_t* idt_ptr) {
+    __asm__ volatile ("lidt %0" : : "m"(*idt_ptr));
+}
+
+static inline uint16_t get_cs(void) {
+    uint16_t cs;
+    __asm__ volatile ("mov %%cs, %0" : "=r"(cs));
+    return cs;
+}
+
+void idt_set_gate(uint8_t num, uint32_t base, uint16_t sel, uint8_t flags) {
+    idt[num].base_low = (uint16_t)(base & 0xFFFF);
+    idt[num].sel      = sel;
+    idt[num].always0  = 0;
+    idt[num].flags    = flags;
+    idt[num].base_high= (uint16_t)((base >> 16) & 0xFFFF);
+}
+
+void idt_install(void) {
+    //zero IDT
+    for (int i = 0; i < 256; ++i) {
+        idt[i].base_low = 0;
+        idt[i].sel = 0;
+        idt[i].always0 = 0;
+        idt[i].flags = 0;
+        idt[i].base_high = 0;
+    }
+
+    //set IRQ gates 32-47
+    uint16_t kcs = get_cs();
+    idt_set_gate(32, (uint32_t)irq0,  kcs, 0x8E);
+    idt_set_gate(33, (uint32_t)irq1,  kcs, 0x8E);
+    idt_set_gate(34, (uint32_t)irq2,  kcs, 0x8E);
+    idt_set_gate(35, (uint32_t)irq3,  kcs, 0x8E);
+    idt_set_gate(36, (uint32_t)irq4,  kcs, 0x8E);
+    idt_set_gate(37, (uint32_t)irq5,  kcs, 0x8E);
+    idt_set_gate(38, (uint32_t)irq6,  kcs, 0x8E);
+    idt_set_gate(39, (uint32_t)irq7,  kcs, 0x8E);
+    idt_set_gate(40, (uint32_t)irq8,  kcs, 0x8E);
+    idt_set_gate(41, (uint32_t)irq9,  kcs, 0x8E);
+    idt_set_gate(42, (uint32_t)irq10, kcs, 0x8E);
+    idt_set_gate(43, (uint32_t)irq11, kcs, 0x8E);
+    idt_set_gate(44, (uint32_t)irq12, kcs, 0x8E);
+    idt_set_gate(45, (uint32_t)irq13, kcs, 0x8E);
+    idt_set_gate(46, (uint32_t)irq14, kcs, 0x8E);
+    idt_set_gate(47, (uint32_t)irq15, kcs, 0x8E);
+
+    idtp.limit = sizeof(idt) - 1;
+    idtp.base  = (uint32_t)&idt[0];
+
+    lidt(&idtp);
+}

--- a/src/interrupts/idt.h
+++ b/src/interrupts/idt.h
@@ -1,0 +1,24 @@
+#ifndef IDT_H
+#define IDT_H
+
+#include <stdint.h>
+
+//32-bit IDT entry
+typedef struct __attribute__((packed)) {
+    uint16_t base_low;   //lower 16 bits of handler address
+    uint16_t sel;        //kernel code segment selector
+    uint8_t  always0;
+    uint8_t  flags;      //present DPL type (0x8E = present ring0 32-bit interrupt gate)
+    uint16_t base_high;  //upper 16 bits of handler address
+} idt_entry_t;
+
+//IDT pointer used by lidt
+typedef struct __attribute__((packed)) {
+    uint16_t limit;
+    uint32_t base;
+} idt_ptr_t;
+
+void idt_install(void);
+void idt_set_gate(uint8_t num, uint32_t base, uint16_t sel, uint8_t flags);
+
+#endif

--- a/src/interrupts/irq.c
+++ b/src/interrupts/irq.c
@@ -1,0 +1,26 @@
+#include "irq.h"
+#include "pic.h"
+
+static irq_handler_t irq_handlers[16] = {0};
+
+void irq_install_handler(int irq, irq_handler_t handler) {
+    if (irq >= 0 && irq < 16) {
+        irq_handlers[irq] = handler;
+    }
+}
+
+void irq_uninstall_handler(int irq) {
+    if (irq >= 0 && irq < 16) {
+        irq_handlers[irq] = 0;
+    }
+}
+
+void irq_dispatch(int irq) {
+    if (irq >= 0 && irq < 16) {
+        irq_handler_t h = irq_handlers[irq];
+        if (h) {
+            h();
+        }
+        pic_send_eoi((uint8_t)irq);
+    }
+}

--- a/src/interrupts/irq.h
+++ b/src/interrupts/irq.h
@@ -1,0 +1,14 @@
+#ifndef IRQ_H
+#define IRQ_H
+
+#include <stdint.h>
+
+typedef void (*irq_handler_t)(void);
+
+void irq_install_handler(int irq, irq_handler_t handler);
+void irq_uninstall_handler(int irq);
+
+//called by assembly stubs
+void irq_dispatch(int irq);
+
+#endif

--- a/src/interrupts/isr.asm
+++ b/src/interrupts/isr.asm
@@ -1,0 +1,148 @@
+[BITS 32]
+section .text
+
+extern irq_dispatch
+
+global irq0
+irq0:
+    pushad
+    push dword 0
+    call irq_dispatch
+    add esp, 4
+    popad
+    iretd
+
+global irq1
+irq1:
+    pushad
+    push dword 1
+    call irq_dispatch
+    add esp, 4
+    popad
+    iretd
+
+global irq2
+irq2:
+    pushad
+    push dword 2
+    call irq_dispatch
+    add esp, 4
+    popad
+    iretd
+
+global irq3
+irq3:
+    pushad
+    push dword 3
+    call irq_dispatch
+    add esp, 4
+    popad
+    iretd
+
+global irq4
+irq4:
+    pushad
+    push dword 4
+    call irq_dispatch
+    add esp, 4
+    popad
+    iretd
+
+global irq5
+irq5:
+    pushad
+    push dword 5
+    call irq_dispatch
+    add esp, 4
+    popad
+    iretd
+
+global irq6
+irq6:
+    pushad
+    push dword 6
+    call irq_dispatch
+    add esp, 4
+    popad
+    iretd
+
+global irq7
+irq7:
+    pushad
+    push dword 7
+    call irq_dispatch
+    add esp, 4
+    popad
+    iretd
+
+global irq8
+irq8:
+    pushad
+    push dword 8
+    call irq_dispatch
+    add esp, 4
+    popad
+    iretd
+
+global irq9
+irq9:
+    pushad
+    push dword 9
+    call irq_dispatch
+    add esp, 4
+    popad
+    iretd
+
+global irq10
+irq10:
+    pushad
+    push dword 10
+    call irq_dispatch
+    add esp, 4
+    popad
+    iretd
+
+global irq11
+irq11:
+    pushad
+    push dword 11
+    call irq_dispatch
+    add esp, 4
+    popad
+    iretd
+
+global irq12
+irq12:
+    pushad
+    push dword 12
+    call irq_dispatch
+    add esp, 4
+    popad
+    iretd
+
+global irq13
+irq13:
+    pushad
+    push dword 13
+    call irq_dispatch
+    add esp, 4
+    popad
+    iretd
+
+global irq14
+irq14:
+    pushad
+    push dword 14
+    call irq_dispatch
+    add esp, 4
+    popad
+    iretd
+
+global irq15
+irq15:
+    pushad
+    push dword 15
+    call irq_dispatch
+    add esp, 4
+    popad
+    iretd

--- a/src/interrupts/pic.c
+++ b/src/interrupts/pic.c
@@ -1,0 +1,66 @@
+#include "pic.h"
+#include "../io.h"
+
+void pic_remap(int offset1, int offset2) {
+    uint8_t a1 = inb(PIC1_DATA);
+    uint8_t a2 = inb(PIC2_DATA);
+
+    //starts the initialization sequence
+    outb(PIC1_COMMAND, 0x11);
+    outb(PIC2_COMMAND, 0x11);
+
+    //set vector offset
+    outb(PIC1_DATA, offset1);
+    outb(PIC2_DATA, offset2);
+
+    //tell master PIC that there is a slave PIC at IRQ2
+    outb(PIC1_DATA, 0x04);
+    //tell slave PIC its cascade identity 
+    outb(PIC2_DATA, 0x02);
+
+    //8086/88 (MCS-80/85) mode
+    outb(PIC1_DATA, 0x01);
+    outb(PIC2_DATA, 0x01);
+
+    //restore saved masks
+    outb(PIC1_DATA, a1);
+    outb(PIC2_DATA, a2);
+}
+
+//send end of interrupt
+void pic_send_eoi(uint8_t irq) {
+    if (irq >= 8) {
+        outb(PIC2_COMMAND, PIC_EOI);
+    }
+    outb(PIC1_COMMAND, PIC_EOI);
+}
+
+//mask an interrupt
+void pic_set_mask(uint8_t irq) {
+    uint16_t port;
+    uint8_t value;
+
+    if (irq < 8) {
+        port = PIC1_DATA;
+    } else {
+        port = PIC2_DATA;
+        irq -= 8;
+    }
+    value = inb(port) | (1 << irq);
+    outb(port, value);
+}
+
+//unmask an interrupt
+void pic_clear_mask(uint8_t irq) {
+    uint16_t port;
+    uint8_t value;
+
+    if (irq < 8) {
+        port = PIC1_DATA;
+    } else {
+        port = PIC2_DATA;
+        irq -= 8;
+    }
+    value = inb(port) & ~(1 << irq);
+    outb(port, value);
+}

--- a/src/interrupts/pic.h
+++ b/src/interrupts/pic.h
@@ -1,0 +1,20 @@
+#ifndef PIC_H
+#define PIC_H
+
+#include <stdint.h>
+
+#define PIC1            0x20
+#define PIC2            0xA0
+#define PIC1_COMMAND    PIC1
+#define PIC1_DATA       (PIC1+1)
+#define PIC2_COMMAND    PIC2
+#define PIC2_DATA       (PIC2+1)
+
+#define PIC_EOI         0x20
+
+void pic_remap(int offset1, int offset2);
+void pic_send_eoi(uint8_t irq);
+void pic_set_mask(uint8_t irq);
+void pic_clear_mask(uint8_t irq);
+
+#endif


### PR DESCRIPTION
added interrupts handling (IDT,IRQ,PIC) (copied from my other OS project, and just changed to fit the architecture of frostbyte) added a timer driver that uses irq0 refactored mouse handling from desktop.c to mouse.c and made the mouse driver interrupt-driven
refactored kernel.c commandloop (input()),iceedit  to use the new keyboard driver the keyboard driver can do both pooling and interrupt-driven, has guardrails to prevent repeating (was a problem when i just implemented the interrupt-driven keyboard) changed PC spekaer to use the interrupt timer, with a fallback to busy-wait loop changed the spinner in beginning of kmain to use the interrupt-timer, didnt implement ISR handling yet which would just call kpanic(); probably